### PR TITLE
Configuración MariaDB

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ itypes
 Jinja2
 jslint
 MarkupSafe
+mysqlclient
 pep8
 phonenumbers
 phonenumberslite

--- a/sigcaw/settings.py
+++ b/sigcaw/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY', '')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get('DEBUG', False)
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [os.environ.get('ALLOWED_HOSTS', '')]
 
 # Application definition
 


### PR DESCRIPTION
Faltaba en requirements.txt
Falla la instalación previamente hay que instalar a nivel de sistema operativo sudo apt-get install libmysqlclient-dev